### PR TITLE
Normalize input to sort showings by date/cinema

### DIFF
--- a/src/components/ShowingByCinema.tsx
+++ b/src/components/ShowingByCinema.tsx
@@ -1,8 +1,8 @@
 import { useRef, useEffect } from "react";
-import { FilmType } from "../types";
+import { TimeSortedFilmType } from "../types";
 
 type ShowingByCinemaProps = {
-  showing: FilmType
+  showing: TimeSortedFilmType
 }
 
 const ShowingByCinema = ({ showing }: ShowingByCinemaProps) => {
@@ -33,6 +33,10 @@ const ShowingByCinema = ({ showing }: ShowingByCinemaProps) => {
       if (activeRef) observer.unobserve(activeRef);
     }
   }, []);
+
+  if (!showing.dates || !Object.keys(showing.dates).length) {
+    return null;
+  }
 
   return (
     <div className="showing-by-cinema-container" ref={showingRef}>
@@ -73,17 +77,17 @@ const ShowingByCinema = ({ showing }: ShowingByCinemaProps) => {
           <span>Cast:</span>
           {showing.cast.split(",").join(", ")}
         </div>
-        {/* loop over show times once data structure is known */}
         <div className="showing-show-times-container">
-          <div className="showing-show-times-row">
-            <div className="showing-show-time-date">17th June</div>
-            <div className="showing-show-time">15:30</div>
-            <div className="showing-show-time">18:30</div>
-          </div>
-          <div className="showing-show-times-row">
-            <div className="showing-show-time-date">21st September</div>
-            <div className="showing-show-time">19:00</div>
-          </div>
+          {Object.keys(showing.dates).map(date => {              
+              return (
+                <div className="showing-show-times-row" key={date}>
+                  <div className="showing-show-time-date">{date}</div>
+                  {showing.dates[date].map(time => {
+                    return <div className="showing-show-time" key={time}>{time}</div>
+                  })}
+                </div>
+              )
+            })}
         </div>
       </div>
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type FilmType = {
+export interface FilmType {
   cast: string,
   cinema_address: string,
   cinema_name: string,
@@ -14,7 +14,19 @@ export type FilmType = {
   rating?: number,
   release_date: string,
   runtime: number,
-  start_time: string,
   synopsis: string,
   tagline: string,
+}
+
+export interface UnsortedFilmType extends FilmType {
+  start_time: {
+    date: string,
+    time: string
+  }
+}
+
+export interface TimeSortedFilmType extends FilmType {
+  dates: {
+    [key: string]: string[];
+  }
 }


### PR DESCRIPTION
- The data returned from the `GET` request contains all individual showings (i.e. a 6 june showing at 6pm and a 6 june showing at 9pm are returned as separate objects) so in this PR, the data is aggregated so that time sorted showings are passed to `ShowingByCinema` (and eventually to `ShowingByFilm` when that is created) so that showing times can be more effectively parsed and displayed