### PR TITLE
Add API call to get cinemas, update error handling

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,11 @@ export interface TimeSortedFilmType extends FilmType {
     [key: string]: string[];
   }
 }
+
+export interface CinemaType {
+  name: string,
+  town: string,
+  additional_info: null,
+  address: string,
+  gps_coordinates: number[]
+}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,10 @@
+import axios, { AxiosError } from "axios";
+
+export const renderError = (err: unknown) => {
+  if (axios.isAxiosError(err)) {
+    const axiosErr = err as AxiosError;
+    console.log("Error:", axiosErr.response?.data || axiosErr.response);
+  } else {
+    console.log(err);
+  }
+}


### PR DESCRIPTION
- Add API call to get a list of cinemas and replace the previous API call with a reusable function that runs for both cinemas and film `GET` requests. This is on a timeout because running 2 API queries to the server without sufficient wait periods can cause temperamental results.
- Update error handling to give more appropriate output for Axios errors