### PR TITLE
Save selectedCinemas for future retrieval

### DIFF
--- a/src/components/CinemaSelector.tsx
+++ b/src/components/CinemaSelector.tsx
@@ -7,13 +7,16 @@ import { CinemaType } from "../types";
 
 type CinemaSelectorProps = {
   cinemas: CinemaType[],
+  selectedCinemas: string[],
   setSelectedCinemas: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const CinemaSelector = ({ cinemas, setSelectedCinemas }: CinemaSelectorProps) => {
-  const [showCinemas, setShowCinemas]  = useState(false);
+const CinemaSelector = ({ cinemas, selectedCinemas, setSelectedCinemas }: CinemaSelectorProps) => {
+  const [showCinemas, setShowCinemas]  = useState(true);
   const cinemaListRef = useRef<HTMLUListElement>(null);
   const cinemaTowns = getCinemaTowns(cinemas);
+
+  const handleDefaultChecked = (cinemaTown: string) => selectedCinemas.includes(cinemaTown) || !selectedCinemas.length;
 
   const handleDeselect = () => {
     if (cinemaListRef.current) {
@@ -29,6 +32,9 @@ const CinemaSelector = ({ cinemas, setSelectedCinemas }: CinemaSelectorProps) =>
       const currentlySelected = cinemas
         .filter(cinema => cinema.checked)
         .map(cinema => cinema.id);
+
+      // Add currentlySelected to local storage for retrieval on next visit
+      localStorage.setItem("selectedCinemas", JSON.stringify(currentlySelected));
       setSelectedCinemas(currentlySelected);
     }
   }
@@ -44,7 +50,13 @@ const CinemaSelector = ({ cinemas, setSelectedCinemas }: CinemaSelectorProps) =>
             {cinemaTowns.map(cinemaTown => {
               return (
                 <li className="cinema-selector-list-item" key={cinemaTown}>
-                  <input className="cinema-selector-input" type="checkbox" id={cinemaTown} value={cinemaTown} defaultChecked />
+                  <input
+                    className="cinema-selector-input"
+                    defaultChecked={handleDefaultChecked(cinemaTown)}
+                    id={cinemaTown}
+                    type="checkbox"
+                    value={cinemaTown}
+                  />
                   <label className="cinema-selector-bubble" htmlFor={cinemaTown}>
                     {cinemaTown}
                   </label>

--- a/src/components/FilmsSection.tsx
+++ b/src/components/FilmsSection.tsx
@@ -16,12 +16,13 @@ const FilmsSection = () => {
   const [showings, setShowings] = useState<UnsortedFilmType[]>([]);
   const [cinemas, setCinemas] = useState<CinemaType[]>([]);
   const [displayBy, setDisplayBy] = useState<DisplayByType>("cinema");
-  const [selectedCinemas, setSelectedCinemas]  = useState<string[]>([]);
+  const storedSelectedCinemas = localStorage.getItem("selectedCinemas");
+  const [selectedCinemas, setSelectedCinemas]  = useState<string[]>(storedSelectedCinemas ? JSON.parse(storedSelectedCinemas) : []);
 
   // The server can be temperamental if multiple queries are performed too close together
   const getData = <T extends FetchedDataType>(
     url: string, 
-    setData: React.Dispatch<React.SetStateAction<T>>, 
+    setData: React.Dispatch<React.SetStateAction<T>>,
     retries = 0
   ) => {
     axios.get<T>(url)
@@ -38,6 +39,7 @@ const FilmsSection = () => {
   };
 
   useEffect(() => {
+    if (selectedCinemas.length) return;
     const cinemaTowns = getCinemaTowns(cinemas);
     setSelectedCinemas(cinemaTowns);
   }, [cinemas]);
@@ -70,7 +72,11 @@ const FilmsSection = () => {
               <span>Film</span>
             </button>
           </div>
-          <CinemaSelector cinemas={cinemas} setSelectedCinemas={setSelectedCinemas} />
+          <CinemaSelector
+            cinemas={cinemas}
+            selectedCinemas={selectedCinemas}
+            setSelectedCinemas={setSelectedCinemas}
+          />
         </div>
         <FilmsContainer displayBy={displayBy} showings={showings} selectedCinemas={selectedCinemas} />
       </div>


### PR DESCRIPTION
- Store a user's selected cinemas so that the page loads their stored ones by default instead of all cinemas
- Show the cinema selector by default, so that users understand why only a few cinemas are showing up if they have previously selected them